### PR TITLE
Require 3.12.9+ for upgrade to 4.0 (previously 3.12.7+)

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -42,23 +42,28 @@ const (
 
 // minPatchForMajorUpgrade defines the minimum source patch version required
 // for an upgrade to the next major X.0. Key is "fromMajor.fromMinor" (e.g. "3.12").
-// Example: 3.12.7+ is required to upgrade to 4.0.
+// Example: 3.12.9+ is required to upgrade to 4.0.
 var minPatchForMajorUpgrade = map[string]int{
-	"3.12": 7, // 3.12.x → 4.0 requires at least 3.12.7
+	"3.12": 9, // 3.12.x → 4.0 requires at least 3.12.9
 }
 
 // parsePatch extracts the numeric patch version (third component) from a driver.Version
 // and reports whether the patch component has a valid format.
 //
 // driver.Version does not expose a Patch() method, so we parse the string form.
-// Examples of supported formats:
 //
-//	"3.12.7"        → 7
-//	"3.12.7-rc1"    → 7
-//	"3.12.7rc1"     → 7
+// Actual 3.12 release versioning:
+//   - Patch: 3.12.9 (three components; the third is the patch number).
+//   - Hotfix: 3.12.9.1, 3.12.9.10, … (four components; fourth is [1-9][0-9]*).
+// As of 3.12, patch and hotfix releases are GA-only; only 3.12.0 had alphas, betas, or RCs.
 //
-// Unsupported patch formats include values that do not start with a digit,
-// e.g. "3.12.rc1".
+// The third numeric component is treated as the patch basis. Supported formats include:
+//
+//	"3.12.9"        → 9   (patch)
+//	"3.12.9.1"      → 9   (hotfix; fourth component ignored for min-patch check)
+//	"3.12.9-rc1"    → 9   (suffix stripped; for generality; 3.12 patch/hotfix are GA-only in practice)
+//
+// Unsupported: patch component does not start with a digit, e.g. "3.12.rc1".
 func parsePatch(v driver.Version) (int, bool) {
 	// Convert version to string (e.g. "3.12.7" or "3.12.7-rc1")
 	s := fmt.Sprint(v)
@@ -195,7 +200,7 @@ func CheckSoftUpgradeRules(from, to driver.Version) error {
 			return fmt.Errorf("Major versions are different: major upgrades are only allowed to X.0")
 		}
 
-		// Enforce minimum patch requirement (e.g. 3.12.7 → 4.0)
+		// Enforce minimum patch requirement (e.g. 3.12.9 → 4.0)
 		if err := checkMinPatchForMajorUpgrade(from, to); err != nil {
 			return err
 		}
@@ -205,7 +210,7 @@ func CheckSoftUpgradeRules(from, to driver.Version) error {
 
 	// ---- Same major version ----
 	// Only major/minor rules: no minimum-patch for minor upgrades.
-	// (Minimum-patch applies only to major upgrade 3.12.7+ → 4.0.)
+	// (Minimum-patch applies only to major upgrade 3.12.9+ → 4.0.)
 
 	if to.Minor() < from.Minor() {
 		return fmt.Errorf("Downgrade of minor version is not allowed")

--- a/rules_test.go
+++ b/rules_test.go
@@ -55,23 +55,42 @@ func TestCheckUpgradeRules(t *testing.T) {
 		{"2.2.3", "1.2.3", false, true},
 		{"1.2.3", "2.2.3", false, false}, // 1→2 but to 2.2 not 2.0, invalid
 
-		// --- Major: 3.x → 4.0 only with 3.12.7+ (minPatchForMajorUpgrade) ---
-		// Same upgrade tested with both checkers: 4th=false → CheckUpgradeRules, 4th=true → CheckSoftUpgradeRules
-		{"3.12.7", "4.0.0", true, false}, // 4th=false: run with CheckUpgradeRules (strict), expect allowed
-		{"3.12.7", "4.0.0", true, true},  // 4th=true:  run with CheckSoftUpgradeRules (soft), expect allowed
-		{"3.12.7-rc1", "4.0.0", true, false},
-		{"3.12.7-rc1", "4.0.0", true, true},
-		{"3.12.8", "4.0.0", true, false},
-		{"3.12.0", "4.0.0", false, false}, // strict: patch < 7
+		// --- Major: 3.x → 4.0 only with 3.12.9+ (minPatchForMajorUpgrade) ---
+
+		// Rejected: patch < 9 (must upgrade to 3.12.9+ before 4.0)
+		{"3.12.0", "4.0.0", false, false},
 		{"3.12.0", "4.0.0", false, true},
 		{"3.12.6", "4.0.0", false, false},
 		{"3.12.6", "4.0.0", false, true},
+		{"3.12.7", "4.0.0", false, false},
+		{"3.12.7", "4.0.0", false, true},
+		{"3.12.7-rc1", "4.0.0", false, false},
+		{"3.12.7-rc1", "4.0.0", false, true},
+		{"3.12.8", "4.0.0", false, false},
+		{"3.12.8", "4.0.0", false, true},
 		{"3.12.rc7", "4.0.0", false, false},
 		{"3.12.rc7", "4.0.0", false, true},
 
-		{"3.11.0", "4.0.0", false, false}, // unlisted source minor must remain disallowed
+		// Allowed: patch 3.12.9 and 3.12.10 (basis >= 9)
+		{"3.12.9", "4.0.0", true, false},
+		{"3.12.9", "4.0.0", true, true},
+		{"3.12.10", "4.0.0", true, false},
+		{"3.12.10", "4.0.0", true, true},
+
+		// Allowed: hotfixes (3.12.9.x, 3.12.10.x — patch basis is 9 or 10)
+		{"3.12.9.1", "4.0.0", true, false},
+		{"3.12.9.1", "4.0.0", true, true},
+		{"3.12.9.11", "4.0.0", true, false},
+		{"3.12.9.11", "4.0.0", true, true},
+		{"3.12.10.1", "4.0.0", true, false},
+		{"3.12.10.1", "4.0.0", true, true},
+		{"3.12.10.9", "4.0.0", true, false},
+		{"3.12.10.9", "4.0.0", true, true},
+
+		// Rejected: other major-upgrade rules (unlisted minor; target not X.0)
+		{"3.11.0", "4.0.0", false, false},
 		{"3.11.0", "4.0.0", false, true},
-		{"3.12.7", "4.1.0", false, false}, // strict: major upgrade to non-X.0 must be rejected
+		{"3.12.7", "4.1.0", false, false},
 		{"3.12.7", "4.1.0", false, true},
 		{"3.12.0", "4.1.0", false, true},
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the enforced version gate for 3.12→4.0 upgrades, which can newly block previously-allowed upgrade paths if callers rely on 3.12.7/3.12.8 being accepted. Includes expanded version parsing expectations (hotfix-style versions) and broader tests, but impacts an operationally sensitive upgrade workflow.
> 
> **Overview**
> Tightens the major-upgrade rule so **3.12→4.0 upgrades require 3.12.9+** (previously 3.12.7+), updating the `minPatchForMajorUpgrade` gate and associated messaging/comments.
> 
> Updates tests to reflect the new minimum and adds coverage for **3.12 hotfix version strings** like `3.12.9.1`/`3.12.10.9` being accepted based on the third (patch) component, while continuing to reject malformed patch formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 570289e820732e5122f4cc9a93b4cbf52ea1c1c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->